### PR TITLE
UPD: JuMP v0.23, Julia min version v1.6 (LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - none
 
+## v0.3.1
+
+- Raise Julia minimum version to v1.6 (LTS)
+- Add JuMP v0.23, Ipopt v1.0 support
+
 ## v0.3.0
 
 - Drop support for JuMP < 0.22

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 PowerModelsDistribution = "d7431456-977f-11e9-2de3-97ff7677985e"
 
 [compat]
@@ -16,6 +17,7 @@ InfrastructureModels = "0.7"
 Ipopt = "0.9, 1.0"
 JSON = "0.21"
 JuMP = "0.22, 0.23"
+Memento = "1"
 PowerModelsDistribution = "0.14"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -2,24 +2,22 @@ name = "PowerModelsStability"
 uuid = "f9e4c324-c3b6-4bca-9c3d-419775f0bd17"
 authors = ["Haoxiang Yang", "Harsha Nagarajan", "David M Fobes"]
 repo = "https://github.com/lanl-ansi/PowerModelsStability.jl.git"
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 PowerModelsDistribution = "d7431456-977f-11e9-2de3-97ff7677985e"
 
 [compat]
-InfrastructureModels = "~0.7"
-Ipopt = "~0.9"
-JSON = "~0.21"
-JuMP = "~0.22"
-Memento = "~1"
-PowerModelsDistribution = "~0.14"
-julia = "^1"
+InfrastructureModels = "0.7"
+Ipopt = "0.9, 1.0"
+JSON = "0.21"
+JuMP = "0.22, 0.23"
+PowerModelsDistribution = "0.14"
+julia = "1.6"
 
 [extras]
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"


### PR DESCRIPTION
- Adds compat for JuMP v0.23
- Bumps minimum version of Julia to v1.6 (LTS)